### PR TITLE
[MRG] automate "test build on pull request" & "update github pages upon merge into main" with actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: build and deploy
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: rmd
+          environment-file: environment.yml
+          python-version: 3.8
+          auto-activate-base: false
+      - name: list conda packages
+        shell: bash -l {0}
+        run: conda list
+      - name: render
+        shell: bash -l {0}
+        run: |
+          Rscript scripts/render_webpages.R
+          find $(pwd)/docs -ls
+      - uses: actions/upload-artifact@v2
+        with:
+          name: rendered-html
+          path: docs/
+      - name: Deploy 🚀
+        if: github.ref == 'refs/heads/main'
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: docs # The folder the action should deploy.
+          CLEAN: true # Automatically remove deleted files from the deploy branch

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ vignettes/*.pdf
 
 # html in pages
 /pages/*.html
+
+# emacs save files
+*~

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+channels:
+    - conda-forge
+    - bioconda
+    - defaults
+dependencies:
+    - r-rmarkdown==2.6
+    - r-rmdformats=1.0.1
+    - r-visnetwork
+    - r-codetools
+    - pandoc>=1.12.3

--- a/pages/build_info.Rmd
+++ b/pages/build_info.Rmd
@@ -1,0 +1,3 @@
+```{r}
+print(system("git rev-parse --short HEAD", intern = TRUE))
+```


### PR DESCRIPTION
This PR configures GitHub Actions on the repo in order to do automated builds on pull requests, as well as to update the `gh-pages` branch once a PR is merged.

Specifically, this PR:
* adds a conda environment file `environment.yml` that installs the R libraries necessary for the build.
* adds a github action in `.github/workflows/build.yml` that checks out the branch and builds it
* updates the `gh-pages` branch with the rendered docs, if the branch being updated is `main` on the enclosing repo
* adds a `build_info` page so that we can check build info on the rendered docs.
* uploads built artifacts for each build (attached to each action's results, under the "actions" menu bar above).

Upon merge, the ucdavisdatalab repository will need to be changed so that the "GitHub Pages" branch points at 'gh-pages'. This branch will be created by the github action.

A few other recommendations:
* I think "squash and merge" should also be set to be the default merge type for PRs, as it leaves the history clean(er).
* branch protection should be set on 'main' so that approving reviews are required for merge from PRs
* we should talk about documenting guidelines for contributors as well as moderators!
* we could add some documentation on how to use the conda environment.yml for people who want to build on their local machine
* for the researcher toolkit pages, it might be nice to have a "date last built, from this source file on github" link on each one.